### PR TITLE
Use with-eval-after-load instead of use-package

### DIFF
--- a/proportional.el
+++ b/proportional.el
@@ -101,10 +101,6 @@ which then is enabled when proportional is enabled."
       (dolist (hook proportional-monospace-hooks)
         (remove-hook hook 'proportional-use-monospace)))))
 
-(eval-when-compile
-  (require 'use-package))
-(require 'use-package)
-
 (defun proportional-which-key-fixer ()
   (when (and (fboundp #'which-key--init-buffer) (boundp 'which-key--buffer))
     (if proportional-mode
@@ -116,16 +112,10 @@ which then is enabled when proportional is enabled."
         (kill-buffer which-key--buffer)
         (setq which-key--buffer nil)))))
 
-(use-package which-key
-  :if (package-installed-p 'which-key)
-  :defer t
-  :config
+(with-eval-after-load 'which-key
   (proportional-which-key-fixer))
 
-(use-package hydra
-  :if (package-installed-p 'hydra)
-  :defer t
-  :config
+(with-eval-after-load 'hydra
   (defadvice lv-message (after proportional)
     (if-let ((buf (get-buffer " *LV*")))
         (with-current-buffer buf


### PR DESCRIPTION
`use-package` is intended for use in user customization only.
It is not intended for use in packages.  It is overkill in
that case and introduces an unnecessary dependency.

For example, this use of the `use-package` macro:

```lisp
    (use-package which-key
      :if (package-installed-p 'which-key)
      :defer t
      :config
      (proportional-which-key-fixer))
```

expands to:

```lisp
    (when (package-installed-p 'which-key)
      (eval-after-load 'which-key
        '(let ((now (current-time)))
           (message "%s..." "Configuring package which-key")
           (prog1 (progn
                    (condition-case-unless-debug err
                        (proportional-which-key-fixer)
                      (error
                       (ignore
                        (display-warning
                         'use-package
                         (format "%s %s: %s" "which-key" ":config"
                                 (error-message-string err))
                         :error))))
                    t)
             (let ((elapsed (float-time (time-subtract (current-time) now))))
               (if (> elapsed 0.1)
                   (message "%s...done (%.3fs)" "Configuring package which-key"
                            elapsed)
                 (message "%s...done" "Configuring package which-key")))))))
```

As you can see there is some duration reporting and error handling
going on.  I would argue that the duration reporting is unnecessary
and even distracting and the error handling is unnecessary too.

If we strip that, we get:

```lisp
    (when (package-installed-p 'which-key)
      (eval-after-load 'which-key
        '(proportional-which-key-fixer)))
```

Since Emacs 24.4 `with-eval-after-load` should be used instead:

```lisp
    (when (package-installed-p 'which-key)
      (with-eval-after-load 'which-key
        (proportional-which-key-fixer)))
```

Now a bug has to be fixed: Not everyone installs packages using
`package.el`.

```lisp
    (with-eval-after-load 'which-key
      (proportional-which-key-fixer))
```

It is my opinion that by doing all this we lose nothing of
significance, but are able to drop a dependency, fix a bug, and make
the package acceptable for Melpa.

Re https://github.com/melpa/melpa/pull/4430.