### PR TITLE
Remove use-package from dependencies

### DIFF
--- a/proportional.el
+++ b/proportional.el
@@ -3,7 +3,7 @@
 ;; Author: Johannes Goslar
 ;; Created: 30 June 2016
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "25.1") (use-package "2.3"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Keywords: faces
 ;; URL: https://github.com/ksjogo/proportional
 


### PR DESCRIPTION
#1 successfully refactors this to work without `use-package`, but it looks like we forgot to remove it from the package's dependencies. Now it shouldn't be installed.

PS: I was just thinking about implementing a similar mode the other day to fix my dired/table formatting woes and this is perfect, thank you!